### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/starbuild.yml
+++ b/.github/workflows/starbuild.yml
@@ -130,6 +130,9 @@ jobs:
     needs: build_matrix
     runs-on: reality-forge
     environment: cosmic-production
+    permissions:
+      contents: read
+      secrets: read
     
     steps:
       - name: "Descargar Artefactos"


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates-v2/security/code-scanning/4](https://github.com/MechBot-2x/mechbot-templates-v2/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `cosmic_integration` job to explicitly define the least privileges required for its operations. Based on the job's steps:
1. The job downloads artifacts, validates them, deploys them, and sends notifications. It likely requires `contents: read` for accessing repository files and `secrets: read` for using deployment keys.
2. Other permissions, such as `issues` or `pull-requests`, are not needed and should not be granted.

The `permissions` block will be added directly under the `cosmic_integration` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
